### PR TITLE
Add @lang declaration for VBA from VB6 language detection

### DIFF
--- a/src/Modules/FormHandler.bas
+++ b/src/Modules/FormHandler.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "FormHandler"
+'@lang VBA
+
 Public LANGUAGES_ As Variant
 ''
 

--- a/src/Modules/Highlight.bas
+++ b/src/Modules/Highlight.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "Highlight"
+'@lang VBA
+
 Public LANGUAGE_ As String
 Public COMMENT_LINE_ As String
 Public COMMENT_MULTILINE_START_ As String

--- a/src/Modules/RibbonRouter.bas
+++ b/src/Modules/RibbonRouter.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "RibbonRouter"
+'@lang VBA
+
 Sub ApplyPythonSyntaxHighlight(control As IRibbonControl)
     
     HighlightSelection "HighlightPython"

--- a/src/Modules/RunDebug.bas
+++ b/src/Modules/RunDebug.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "RunDebug"
+'@lang VBA
+
 Sub RunDebug()
     ' This Sub is here for testing purposes so there is no reliance on the ribbon button
     ' Replace the func variable with the Sub you want to call.

--- a/src/Modules/constC.bas
+++ b/src/Modules/constC.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "constC"
+'@lang VBA
+
 Public Sub HighlightC()
      
     LANGUAGE_ = "Code"

--- a/src/Modules/constCpp.bas
+++ b/src/Modules/constCpp.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "constCPP"
+'@lang VBA
+
 Public Sub HighlightCpp()
      
     LANGUAGE_ = "Code"

--- a/src/Modules/constCsharp.bas
+++ b/src/Modules/constCsharp.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "constCsharp"
+'@lang VBA
+
 Public Sub HighlightCsharp()
      
     LANGUAGE_ = "Code"

--- a/src/Modules/constHtml.bas
+++ b/src/Modules/constHtml.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "constHtml"
+'@lang VBA
+
 Public Sub HighlightHtml()
      
     LANGUAGE_ = "Markup"

--- a/src/Modules/constJava.bas
+++ b/src/Modules/constJava.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "constJava"
+'@lang VBA
+
 Public Sub HighlightJava()
      
     LANGUAGE_ = "Code"

--- a/src/Modules/constJson.bas
+++ b/src/Modules/constJson.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "constJson"
+'@lang VBA
+
 Public Sub HighlightJson()
      
     LANGUAGE_ = "Code"

--- a/src/Modules/constPython.bas
+++ b/src/Modules/constPython.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "constPython"
+'@lang VBA
+
 Public Sub HighlightPython()
      
     LANGUAGE_ = "Code"

--- a/src/Modules/constShell.bas
+++ b/src/Modules/constShell.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "constShell"
+'@lang VBA
+
 Public Sub HighlightShell()
 
     LANGUAGE_ = "Shell"

--- a/src/Modules/constXml.bas
+++ b/src/Modules/constXml.bas
@@ -1,4 +1,6 @@
 Attribute VB_Name = "constXml"
+'@lang VBA
+
 Public Sub HighlightXml()
      
     LANGUAGE_ = "Markup"


### PR DESCRIPTION
Simple addition of `'@lang VBA` for all bas files to ensure these are picked up by github as VBA files, not VB6

Before:

![image](https://github.com/user-attachments/assets/e2f2c03f-1eff-4afa-8dd5-c54fbb61c26e)

After:

![image](https://github.com/user-attachments/assets/a29af744-991e-4667-a029-e4d1e9be058f)
